### PR TITLE
MAINT: repro ResNest200e, 512x512 (CV: 0.9558)

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,2 @@
+[cache]
+    dir = /data/dvc-cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 .ipynb_checkpoints
 .nvimlog
+.vim/
 *.egg-info/
 lightning_logs/
 run_1080.sh

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,518 +1,533 @@
-download_data:
-  cmd: kaggle competitions download -c ranzcr-clip-catheter-line-classification -p
-    data/
-  outs:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-unzip_train_img:
-  cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train/*' -d 'data/'
-  deps:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-  outs:
-  - path: data/train/
-    md5: 5571d6d885d1e550ac890552afb255f0.dir
-    size: 6912613778
-    nfiles: 30083
-unzip_test_img:
-  cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'test/*' -d 'data/'
-  deps:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-  outs:
-  - path: data/test/
-    md5: ac6babfae020e79d81c0cd2ed33b7bd6.dir
-    size: 844745721
-    nfiles: 3583
-unzip_train_labels:
-  cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train.csv' -d 'data/'
-  deps:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-  outs:
-  - path: data/train.csv
-    md5: f9305cb1f8dbb233c78385f20ab3ae72
-    size: 2918266
-unzip_train_annotations:
-  cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train_annotations.csv'
-    -d 'data/'
-  deps:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-  outs:
-  - path: data/train_annotations.csv
-    md5: 00ad55b088b2f81c756a6b21bc8f2562
-    size: 4950273
-create_folds:
-  cmd: python pipe/create_folds.py
-  deps:
-  - path: data/train.csv
-    md5: f9305cb1f8dbb233c78385f20ab3ae72
-    size: 2918266
-  - path: pipe/create_folds.py
-    md5: 78d346827bae71e4e2057bf148f94038
-    size: 723
-  outs:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-unzip_sample_submission:
-  cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'sample_submission.csv'
-    -d 'data/'
-  deps:
-  - path: data/ranzcr-clip-catheter-line-classification.zip
-    md5: f8a117e7ba1b5527c99c80b54beddeb5
-    size: 12561354247
-  outs:
-  - path: data/sample_submission.csv
-    md5: 3bf8eb33a1a25f1f79940d019c18ebbc
-    size: 311839
-resize_images:
-  cmd: python pipe/resize_images.py
-  deps:
-  - path: data/test/
-    md5: ac6babfae020e79d81c0cd2ed33b7bd6.dir
-    size: 844745721
-    nfiles: 3583
-  - path: data/train/
-    md5: 5571d6d885d1e550ac890552afb255f0.dir
-    size: 6912613778
-    nfiles: 30083
-  outs:
-  - path: data/test_1024/
-    md5: 29b494965aebb0664b74e29f3e345473.dir
-    size: 214944270
-    nfiles: 3582
-  - path: data/test_128/
-    md5: 105566336a8298b416d0ef82e347051d.dir
-    size: 8846772
-    nfiles: 3582
-  - path: data/test_192/
-    md5: 7872b7646f388e9b08695138794c757a.dir
-    size: 15818222
-    nfiles: 3582
-  - path: data/test_256/
-    md5: 0a364a5a19354e2080a27411a6996ab5.dir
-    size: 24363993
-    nfiles: 3582
-  - path: data/test_384/
-    md5: 85def42fb4ea189dc50f2950f3b88965.dir
-    size: 45232275
-    nfiles: 3582
-  - path: data/test_512/
-    md5: 829fb8073ab10e5ace5d6d05253387b3.dir
-    size: 70444379
-    nfiles: 3582
-  - path: data/test_768/
-    md5: 9275cfb3acc8651983a9eb43ca03b174.dir
-    size: 133274447
-    nfiles: 3582
-  - path: data/train_1024/
-    md5: 2f49375e6e8e87e1fab5c5075d63b582.dir
-    size: 1773270872
-    nfiles: 30083
-  - path: data/train_128/
-    md5: 569de16f618eff737a4f2a8d3e70eec0.dir
-    size: 72692224
-    nfiles: 30083
-  - path: data/train_192/
-    md5: c480a05f5643a38909ccad7f71000599.dir
-    size: 130326145
-    nfiles: 30083
-  - path: data/train_256/
-    md5: e14002093f230017b4cc1810a53f0328.dir
-    size: 201194414
-    nfiles: 30083
-  - path: data/train_384/
-    md5: 142193318e2adfddd4fb6f8551589009.dir
-    size: 374049179
-    nfiles: 30083
-  - path: data/train_512/
-    md5: 088e837dc33da0b21e3f57644c085037.dir
-    size: 582432616
-    nfiles: 30083
-  - path: data/train_768/
-    md5: 8695f5a4249f99244a4c8c14e15eac0a.dir
-    size: 1100286799
-    nfiles: 30083
-train_modlel_02:
-  cmd: python pipe/train.py --fold 0 --epochs 20 --arch resnet34 --metric multilabel_auc_macro
-    --opt adam --loss bce_with_logits --precision 16 --sz 128 --bs 512  --lr 0.02
-    --wd 0.02 --mom 0.9
-  deps:
-  - path: data/train_folds.csv
-    md5: c0a7355a820dd5f371ba3ffb54eeecd0
-    size: 2978438
-  - path: pipe/train.py
-    md5: 07a367a146265f74db1e04c9d0a0d049
-    size: 4289
-  outs:
-  - path: models/arch=resnet34_sz=128_fold=0.ckpt
-    md5: 58672e048799379a17223652040325fd
-    size: 85284057
-  - path: subs/oof/arch=resnet34_sz=128_fold=0.csv
-    md5: 125c6c3ae07a99c6d53e0830d10d2e2e
-    size: 986208
-train_resnet18_256:
-  cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
-    --epochs 15 --arch resnet18 --sz 256 --batch_size 128 --lr 1 --sched onecycle
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 97ab92d24da766cb621b43d4749ec8c8
-    size: 7224
-  outs:
-  - path: metrics/arch=resnet18_sz=256.metric
-    md5: 200784b2c007da87dad50f7d46c73b48
-    size: 31
-  - path: models/arch=resnet18_sz=256_fold=0.ckpt
-    md5: a90f7cd96c78bb32037f7d53f4e44f6c
-    size: 44787193
-  - path: models/arch=resnet18_sz=256_fold=1.ckpt
-    md5: 6b48bf222f4a67444615e48d02fc65f3
-    size: 44787193
-  - path: models/arch=resnet18_sz=256_fold=2.ckpt
-    md5: b744500a91a2af01cbb0f955f1c3555f
-    size: 44787193
-  - path: models/arch=resnet18_sz=256_fold=3.ckpt
-    md5: 8a6018657d4d944294718ed0e249be97
-    size: 44787193
-  - path: models/arch=resnet18_sz=256_fold=4.ckpt
-    md5: 1ddfb3ee80d990a2e27845355c8265ab
-    size: 44787193
-  - path: subs/arch=resnet18_sz=256_fold=0.csv
-    md5: 90c06f647ffcd6fe8adf8f2818dbde8b
-    size: 993174
-  - path: subs/arch=resnet18_sz=256_fold=1.csv
-    md5: 57d8fffd5ffeac0233186d711bd0277f
-    size: 994569
-  - path: subs/arch=resnet18_sz=256_fold=2.csv
-    md5: f541fb2734f23708a8286e5815431510
-    size: 991653
-  - path: subs/arch=resnet18_sz=256_fold=3.csv
-    md5: e00bdbbe2748947126720a6fb5761fba
-    size: 993150
-  - path: subs/arch=resnet18_sz=256_fold=4.csv
-    md5: d24589d03fac10bdbf9aeaf3c1d88587
-    size: 994248
-  - path: subs/oof/arch=resnet18_sz=256_fold=0.csv
-    md5: 4f203721e2017a27fb3530b95824a59e
-    size: 1678199
-  - path: subs/oof/arch=resnet18_sz=256_fold=1.csv
-    md5: 27e19c7055ca010230f0246ff0ae7bee
-    size: 1679626
-  - path: subs/oof/arch=resnet18_sz=256_fold=2.csv
-    md5: 3773f15529ddeec8ac40cd07c82b5c85
-    size: 1679875
-  - path: subs/oof/arch=resnet18_sz=256_fold=3.csv
-    md5: e6d4234aed69cc82c652943247385562
-    size: 1680644
-  - path: subs/oof/arch=resnet18_sz=256_fold=4.csv
-    md5: c5c09c85224c872e85515e8cb8a87332
-    size: 1678591
-train_resnet18_512:
-  cmd: python pipe/train.py --train_data train_512 --test_data test_512 --fold -1
-    --epochs 15 --arch resnet18 --sz 512 --auto_batch_size power --lr 1 --sched onecycle
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 97ab92d24da766cb621b43d4749ec8c8
-    size: 7224
-  outs:
-  - path: metrics/arch=resnet18_sz=512.metric
-    md5: 2310a59a6f2dbc8aa1b868287e705ad9
-    size: 31
-  - path: models/arch=resnet18_sz=512_fold=0.ckpt
-    md5: 418b214287bd6bf8870f9dcfd6129fcd
-    size: 44787201
-  - path: models/arch=resnet18_sz=512_fold=1.ckpt
-    md5: 7d75ff564bd3de5ce0d27b3dfec0bdcb
-    size: 44787198
-  - path: models/arch=resnet18_sz=512_fold=2.ckpt
-    md5: 4c77426416a120568d28e83ca3b6b599
-    size: 44787197
-  - path: models/arch=resnet18_sz=512_fold=3.ckpt
-    md5: 367b5fe5bd4ca0107421690d7fa60da2
-    size: 44787197
-  - path: models/arch=resnet18_sz=512_fold=4.ckpt
-    md5: bd24dcb589fe3f1be741bb541415e161
-    size: 44787198
-  - path: subs/arch=resnet18_sz=512_fold=0.csv
-    md5: 0a4cf03f080c057d3926f93f2bb85fe6
-    size: 994293
-  - path: subs/arch=resnet18_sz=512_fold=1.csv
-    md5: 86063ba3f5fa844b40aef0c5259f8d54
-    size: 995216
-  - path: subs/arch=resnet18_sz=512_fold=2.csv
-    md5: e8513a45c610331046faeb26eca41bed
-    size: 992202
-  - path: subs/arch=resnet18_sz=512_fold=3.csv
-    md5: a2f83ff1d408e4884532037f8a7eeba6
-    size: 997531
-  - path: subs/arch=resnet18_sz=512_fold=4.csv
-    md5: 51087d2261ec537608308ca6c9204445
-    size: 998571
-  - path: subs/oof/arch=resnet18_sz=512_fold=0.csv
-    md5: 3d7d33ab2227347a65c5a7ad2214b25c
-    size: 1678290
-  - path: subs/oof/arch=resnet18_sz=512_fold=1.csv
-    md5: 0f4d38917c582dda9f4136416f0d4918
-    size: 1678835
-  - path: subs/oof/arch=resnet18_sz=512_fold=2.csv
-    md5: 6463e058c216c9c3d6f2f890398d5578
-    size: 1678860
-  - path: subs/oof/arch=resnet18_sz=512_fold=3.csv
-    md5: 30b6300789b85f9cf8ce067ca905a696
-    size: 1685707
-  - path: subs/oof/arch=resnet18_sz=512_fold=4.csv
-    md5: e80d686815502a81e952250535ca5d08
-    size: 1683124
-train_efficientnet_b4_256:
-  cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
-    --epochs 15 --arch tf_efficientnet_b4_ns --sz 256 --batch_size 22 --lr 1 --sched
-    onecycle
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 2dfbac030cc5c89a17585ef832abdd7b
-    size: 8159
-  outs:
-  - path: metrics/arch=tf_efficientnet_b4_ns_sz=256.metric
-    md5: bd9e8cc3f4ccb693714fac3cff80ab2d
-    size: 49
-  - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=0.ckpt
-    md5: bc1e0ca47a6f9091e7b1871ed2de9cdf
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=1.ckpt
-    md5: 741fbad628a17a75244da7e0d3ab4291
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=2.ckpt
-    md5: 3227695bfacb4b61f17534b8c92d430c
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=3.ckpt
-    md5: 7c0821d6bf95220c47e0f2c86d83e92e
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=4.ckpt
-    md5: 329b4ed99b0ea1ef0f365578a9f86df5
-    size: 71032001
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
-    md5: 5230282872626885db68bd6bfc9d17d2
-    size: 994046
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
-    md5: ff13e4d7746903b6e6bf23c3012ce077
-    size: 989997
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
-    md5: 995818cc457d53adb53364e06f7e8825
-    size: 991256
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
-    md5: c8b1d07acb34b9f50cd7794daf44878f
-    size: 992262
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
-    md5: 8bff869fffc12588d077f5906ccdd08d
-    size: 990444
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
-    md5: fd11768d79e28f48f32d329c9bc6cffa
-    size: 1676231
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
-    md5: 036b82adc98aa8b2e8e726a2b0ae31b7
-    size: 1671098
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
-    md5: a7bd54d47f8e9dec34e5cbc3c60ab39b
-    size: 1677398
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
-    md5: 4a7948a30acfc25b95a641f2071f3e99
-    size: 1677331
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
-    md5: 57509c9dcad5e1cb1ebb909220cdb203
-    size: 1671019
-train_efficientnet_b4_512:
-  cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-    --epochs 5 --arch tf_efficientnet_b4_ns --sz 512 --batch_size 32 --lr 1 --sched
-    onecycle
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 9fa4cbc5ffe416f796e046ab1f5b97aa
-    size: 8840
-  outs:
-  - path: metrics/arch=tf_efficientnet_b4_ns_sz=512.metric
-    md5: 8f249f493c246e633f4feaf66fe0755d
-    size: 49
-  - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=0.ckpt
-    md5: b50c09f05c3fa2edd67cf5d8f56e9f4b
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=1.ckpt
-    md5: 4e9fd595aebb4eab6e93ba71b6e685e7
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=2.ckpt
-    md5: 0c0d03a0ff939f067e048a1c96f9ead0
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=3.ckpt
-    md5: cebf80349f593f420722dbaacdfb1e03
-    size: 71032001
-  - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=4.ckpt
-    md5: ad292afdefcb7106bf1d8bbb34034d31
-    size: 71032001
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
-    md5: 2a9d108e226095387969d7854505149b
-    size: 999503
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
-    md5: b071f6b03cb4bcaceeb8eea8a7cfaf20
-    size: 999754
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
-    md5: 0464bc8e1ba695af872b7ef8afe1f408
-    size: 1000900
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
-    md5: 160d19a783da83ed81ca79ff558b971d
-    size: 998228
-  - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
-    md5: 5e7a2b18cab6a080dd7f3cd7a66ed0fd
-    size: 996537
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
-    md5: d5f5c9c7b4eaef7e9d8bd2ec4594c737
-    size: 1668531
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
-    md5: 5dec21676d59981c849ffdb65f5c1dff
-    size: 1671022
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
-    md5: a2eb95d767e19210db53c513008a974f
-    size: 1671474
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
-    md5: b8174b190fe201af011a49ec9682e4aa
-    size: 1670604
-  - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
-    md5: e9468e76b7672018833b04f1c28adfa2
-    size: 1673483
-train_resnest14d_128:
-  cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
-    --epochs 15 --arch resnest14d --sz 128 --batch_size 128 --lr 1 --wd 0.00001 --label_smoothing
-    0.05 --sched onecycle --aug baseline --precision 32 --opt sam
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: eff5e803fbb6738cc712757f68bd0990
-    size: 5578
-  outs:
-  - path: metrics/arch=resnest14d_sz=128.metric
-    md5: 159e17d940a3b86eacdee5cf3928374a
-    size: 49
-  - path: models/arch=resnest14d_sz=128_fold=0.ckpt
-    md5: 399813e5f561efa3b203ee4dada0c4c9
-    size: 68863803
-  - path: models/arch=resnest14d_sz=128_fold=1.ckpt
-    md5: 6b13a1f78cf1f38c01e4927bd110d73d
-    size: 68863869
-  - path: models/arch=resnest14d_sz=128_fold=2.ckpt
-    md5: 9293c31e4547d8373068e7a8dd6a50ef
-    size: 68863803
-  - path: models/arch=resnest14d_sz=128_fold=3.ckpt
-    md5: 22515f01f0974a301938c13468476698
-    size: 68863870
-  - path: models/arch=resnest14d_sz=128_fold=4.ckpt
-    md5: 809171593ec46cdb2f4a2ab30906a75f
-    size: 68863803
-train_resnest101e_512:
-  cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-    --epochs 10 --arch resnest101e --sz 512 --batch_size 16 --lr .1 --wd 0.00001 --label_smoothing
-    0.05 --sched onecycle --aug baseline --precision 32 --opt sam
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 7b347936343e1135b4cb5faaf9e1153a
-    size: 5888
-  outs:
-  - path: metrics/arch=resnest101e_sz=512.metric
-    md5: 7da3b3c004a251ec0fcb1d1dee001381
-    size: 50
-  - path: models/arch=resnest101e_sz=512_fold=0.ckpt
-    md5: bcec379952017b9f84af5ff871fefaa9
-    size: 371087053
-  - path: models/arch=resnest101e_sz=512_fold=1.ckpt
-    md5: ed6851233b5246341f380a8b8811c21c
-    size: 371087054
-  - path: models/arch=resnest101e_sz=512_fold=2.ckpt
-    md5: 25c845fcdb94fc45e7da3f349a04b489
-    size: 371087053
-  - path: models/arch=resnest101e_sz=512_fold=3.ckpt
-    md5: e6805294f7833e4bd3ea4fc8beb938b4
-    size: 371087053
-  - path: models/arch=resnest101e_sz=512_fold=4.ckpt
-    md5: 3ec2bd018dd0aa3ee2a4b88932128133
-    size: 371087053
-train_resnest200e_512:
-  cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-    --epochs 10 --arch resnest200e --sz 512 --batch_size 8 --lr .1 --wd 0.00001 --label_smoothing
-    0.05 --sched onecycle --aug baseline --precision 32 --opt sam
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 7b347936343e1135b4cb5faaf9e1153a
-    size: 5888
-  outs:
-  - path: metrics/arch=resnest200e_sz=512.metric
-    md5: 45443f9e76ec882e478e7f1155351074
-    size: 49
-  - path: models/arch=resnest200e_sz=512_fold=0.ckpt
-    md5: eb8e9a71cb1405bdf55c659546a4bfa4
-    size: 547410631
-  - path: models/arch=resnest200e_sz=512_fold=1.ckpt
-    md5: ab76b5cb305ea4fac0351effde796025
-    size: 547410695
-  - path: models/arch=resnest200e_sz=512_fold=2.ckpt
-    md5: 116eebed3a86e45283d547c1360d95d4
-    size: 547410695
-  - path: models/arch=resnest200e_sz=512_fold=3.ckpt
-    md5: 0e73a1162d8b358b416c1fc8f934fd2a
-    size: 547410695
-  - path: models/arch=resnest200e_sz=512_fold=4.ckpt
-    md5: 3ea82ac4faa0f38533702ecc4b17e068
-    size: 547410695
-train_resnest50d_512:
-  cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-    --epochs 10 --arch resnest50d --sz 512 --batch_size 32 --lr .1 --wd 0.00001 --label_smoothing
-    0.05 --sched onecycle --aug baseline --precision 32 --opt sam
-  deps:
-  - path: data/train_folds.csv
-    md5: 7a364fa00309d9d50641ae5edcfabcd3
-    size: 2978438
-  - path: pipe/train.py
-    md5: 7b347936343e1135b4cb5faaf9e1153a
-    size: 5888
-  outs:
-  - path: metrics/arch=resnest50d_sz=512.metric
-    md5: 8a7ffe01e5ceaa8dfc315d481fe8287e
-    size: 50
-  - path: models/arch=resnest50d_sz=512_fold=0.ckpt
-    md5: 026c0a1d823cdd47fedcb714faf3d322
-    size: 204207475
-  - path: models/arch=resnest50d_sz=512_fold=1.ckpt
-    md5: 6c1c4e01bd959814f902430c03a3131a
-    size: 204207476
-  - path: models/arch=resnest50d_sz=512_fold=2.ckpt
-    md5: 934c4bcbf3f80308e4e1bff47490e0b3
-    size: 204207475
-  - path: models/arch=resnest50d_sz=512_fold=3.ckpt
-    md5: 0e1ee21057f39e84ab49c4431769f963
-    size: 204207475
-  - path: models/arch=resnest50d_sz=512_fold=4.ckpt
-    md5: c279403b0e673563bb04e9c9603eb8a1
-    size: 204207476
+schema: '2.0'
+stages:
+  download_data:
+    cmd: kaggle competitions download -c ranzcr-clip-catheter-line-classification
+      -p data/
+    outs:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+  unzip_train_img:
+    cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train/*' -d 'data/'
+    deps:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+    outs:
+    - path: data/train/
+      md5: 5571d6d885d1e550ac890552afb255f0.dir
+      size: 6912613778
+      nfiles: 30083
+  unzip_test_img:
+    cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'test/*' -d 'data/'
+    deps:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+    outs:
+    - path: data/test/
+      md5: 45cbe64f56a418f4d1abebd38c184175.dir
+      size: 844424034
+      nfiles: 3582
+  unzip_train_labels:
+    cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train.csv' -d 'data/'
+    deps:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+    outs:
+    - path: data/train.csv
+      md5: f9305cb1f8dbb233c78385f20ab3ae72
+      size: 2918266
+  unzip_train_annotations:
+    cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'train_annotations.csv'
+      -d 'data/'
+    deps:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+    outs:
+    - path: data/train_annotations.csv
+      md5: 00ad55b088b2f81c756a6b21bc8f2562
+      size: 4950273
+  create_folds:
+    cmd: python pipe/create_folds.py
+    deps:
+    - path: data/train.csv
+      md5: f9305cb1f8dbb233c78385f20ab3ae72
+      size: 2918266
+    - path: pipe/create_folds.py
+      md5: 78d346827bae71e4e2057bf148f94038
+      size: 723
+    outs:
+    - path: data/train_folds.csv
+      md5: 7f4f0d6630400e2b1218d530fcb99a63
+      size: 2978438
+  unzip_sample_submission:
+    cmd: unzip data/ranzcr-clip-catheter-line-classification.zip 'sample_submission.csv'
+      -d 'data/'
+    deps:
+    - path: data/ranzcr-clip-catheter-line-classification.zip
+      md5: f8a117e7ba1b5527c99c80b54beddeb5
+      size: 12561354247
+    outs:
+    - path: data/sample_submission.csv
+      md5: 3bf8eb33a1a25f1f79940d019c18ebbc
+      size: 311839
+  resize_images:
+    cmd: python pipe/resize_images.py
+    deps:
+    - path: data/test/
+      md5: 45cbe64f56a418f4d1abebd38c184175.dir
+      size: 844424034
+      nfiles: 3582
+    - path: data/train/
+      md5: 5571d6d885d1e550ac890552afb255f0.dir
+      size: 6912613778
+      nfiles: 30083
+    outs:
+    - path: data/test_1024/
+      md5: 29b494965aebb0664b74e29f3e345473.dir
+      size: 214944270
+      nfiles: 3582
+    - path: data/test_128/
+      md5: 105566336a8298b416d0ef82e347051d.dir
+      size: 8846772
+      nfiles: 3582
+    - path: data/test_192/
+      md5: 7872b7646f388e9b08695138794c757a.dir
+      size: 15818222
+      nfiles: 3582
+    - path: data/test_256/
+      md5: 0a364a5a19354e2080a27411a6996ab5.dir
+      size: 24363993
+      nfiles: 3582
+    - path: data/test_384/
+      md5: 85def42fb4ea189dc50f2950f3b88965.dir
+      size: 45232275
+      nfiles: 3582
+    - path: data/test_512/
+      md5: 829fb8073ab10e5ace5d6d05253387b3.dir
+      size: 70444379
+      nfiles: 3582
+    - path: data/test_768/
+      md5: 9275cfb3acc8651983a9eb43ca03b174.dir
+      size: 133274447
+      nfiles: 3582
+    - path: data/train_1024/
+      md5: 2f49375e6e8e87e1fab5c5075d63b582.dir
+      size: 1773270872
+      nfiles: 30083
+    - path: data/train_128/
+      md5: 569de16f618eff737a4f2a8d3e70eec0.dir
+      size: 72692224
+      nfiles: 30083
+    - path: data/train_192/
+      md5: c480a05f5643a38909ccad7f71000599.dir
+      size: 130326145
+      nfiles: 30083
+    - path: data/train_256/
+      md5: e14002093f230017b4cc1810a53f0328.dir
+      size: 201194414
+      nfiles: 30083
+    - path: data/train_384/
+      md5: 142193318e2adfddd4fb6f8551589009.dir
+      size: 374049179
+      nfiles: 30083
+    - path: data/train_512/
+      md5: 088e837dc33da0b21e3f57644c085037.dir
+      size: 582432616
+      nfiles: 30083
+    - path: data/train_768/
+      md5: 8695f5a4249f99244a4c8c14e15eac0a.dir
+      size: 1100286799
+      nfiles: 30083
+  train_modlel_02:
+    cmd: python pipe/train.py --fold 0 --epochs 20 --arch resnet34 --metric multilabel_auc_macro
+      --opt adam --loss bce_with_logits --precision 16 --sz 128 --bs 512  --lr 0.02
+      --wd 0.02 --mom 0.9
+    deps:
+    - path: data/train_folds.csv
+      md5: c0a7355a820dd5f371ba3ffb54eeecd0
+      size: 2978438
+    - path: pipe/train.py
+      md5: 07a367a146265f74db1e04c9d0a0d049
+      size: 4289
+    outs:
+    - path: models/arch=resnet34_sz=128_fold=0.ckpt
+      md5: 58672e048799379a17223652040325fd
+      size: 85284057
+    - path: subs/oof/arch=resnet34_sz=128_fold=0.csv
+      md5: 125c6c3ae07a99c6d53e0830d10d2e2e
+      size: 986208
+  train_resnet18_256:
+    cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
+      --epochs 15 --arch resnet18 --sz 256 --batch_size 128 --lr 1 --sched onecycle
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 97ab92d24da766cb621b43d4749ec8c8
+      size: 7224
+    outs:
+    - path: metrics/arch=resnet18_sz=256.metric
+      md5: 200784b2c007da87dad50f7d46c73b48
+      size: 31
+    - path: models/arch=resnet18_sz=256_fold=0.ckpt
+      md5: a90f7cd96c78bb32037f7d53f4e44f6c
+      size: 44787193
+    - path: models/arch=resnet18_sz=256_fold=1.ckpt
+      md5: 6b48bf222f4a67444615e48d02fc65f3
+      size: 44787193
+    - path: models/arch=resnet18_sz=256_fold=2.ckpt
+      md5: b744500a91a2af01cbb0f955f1c3555f
+      size: 44787193
+    - path: models/arch=resnet18_sz=256_fold=3.ckpt
+      md5: 8a6018657d4d944294718ed0e249be97
+      size: 44787193
+    - path: models/arch=resnet18_sz=256_fold=4.ckpt
+      md5: 1ddfb3ee80d990a2e27845355c8265ab
+      size: 44787193
+    - path: subs/arch=resnet18_sz=256_fold=0.csv
+      md5: 90c06f647ffcd6fe8adf8f2818dbde8b
+      size: 993174
+    - path: subs/arch=resnet18_sz=256_fold=1.csv
+      md5: 57d8fffd5ffeac0233186d711bd0277f
+      size: 994569
+    - path: subs/arch=resnet18_sz=256_fold=2.csv
+      md5: f541fb2734f23708a8286e5815431510
+      size: 991653
+    - path: subs/arch=resnet18_sz=256_fold=3.csv
+      md5: e00bdbbe2748947126720a6fb5761fba
+      size: 993150
+    - path: subs/arch=resnet18_sz=256_fold=4.csv
+      md5: d24589d03fac10bdbf9aeaf3c1d88587
+      size: 994248
+    - path: subs/oof/arch=resnet18_sz=256_fold=0.csv
+      md5: 4f203721e2017a27fb3530b95824a59e
+      size: 1678199
+    - path: subs/oof/arch=resnet18_sz=256_fold=1.csv
+      md5: 27e19c7055ca010230f0246ff0ae7bee
+      size: 1679626
+    - path: subs/oof/arch=resnet18_sz=256_fold=2.csv
+      md5: 3773f15529ddeec8ac40cd07c82b5c85
+      size: 1679875
+    - path: subs/oof/arch=resnet18_sz=256_fold=3.csv
+      md5: e6d4234aed69cc82c652943247385562
+      size: 1680644
+    - path: subs/oof/arch=resnet18_sz=256_fold=4.csv
+      md5: c5c09c85224c872e85515e8cb8a87332
+      size: 1678591
+  train_resnet18_512:
+    cmd: python pipe/train.py --train_data train_512 --test_data test_512 --fold -1
+      --epochs 15 --arch resnet18 --sz 512 --auto_batch_size power --lr 1 --sched
+      onecycle
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 97ab92d24da766cb621b43d4749ec8c8
+      size: 7224
+    outs:
+    - path: metrics/arch=resnet18_sz=512.metric
+      md5: 2310a59a6f2dbc8aa1b868287e705ad9
+      size: 31
+    - path: models/arch=resnet18_sz=512_fold=0.ckpt
+      md5: 418b214287bd6bf8870f9dcfd6129fcd
+      size: 44787201
+    - path: models/arch=resnet18_sz=512_fold=1.ckpt
+      md5: 7d75ff564bd3de5ce0d27b3dfec0bdcb
+      size: 44787198
+    - path: models/arch=resnet18_sz=512_fold=2.ckpt
+      md5: 4c77426416a120568d28e83ca3b6b599
+      size: 44787197
+    - path: models/arch=resnet18_sz=512_fold=3.ckpt
+      md5: 367b5fe5bd4ca0107421690d7fa60da2
+      size: 44787197
+    - path: models/arch=resnet18_sz=512_fold=4.ckpt
+      md5: bd24dcb589fe3f1be741bb541415e161
+      size: 44787198
+    - path: subs/arch=resnet18_sz=512_fold=0.csv
+      md5: 0a4cf03f080c057d3926f93f2bb85fe6
+      size: 994293
+    - path: subs/arch=resnet18_sz=512_fold=1.csv
+      md5: 86063ba3f5fa844b40aef0c5259f8d54
+      size: 995216
+    - path: subs/arch=resnet18_sz=512_fold=2.csv
+      md5: e8513a45c610331046faeb26eca41bed
+      size: 992202
+    - path: subs/arch=resnet18_sz=512_fold=3.csv
+      md5: a2f83ff1d408e4884532037f8a7eeba6
+      size: 997531
+    - path: subs/arch=resnet18_sz=512_fold=4.csv
+      md5: 51087d2261ec537608308ca6c9204445
+      size: 998571
+    - path: subs/oof/arch=resnet18_sz=512_fold=0.csv
+      md5: 3d7d33ab2227347a65c5a7ad2214b25c
+      size: 1678290
+    - path: subs/oof/arch=resnet18_sz=512_fold=1.csv
+      md5: 0f4d38917c582dda9f4136416f0d4918
+      size: 1678835
+    - path: subs/oof/arch=resnet18_sz=512_fold=2.csv
+      md5: 6463e058c216c9c3d6f2f890398d5578
+      size: 1678860
+    - path: subs/oof/arch=resnet18_sz=512_fold=3.csv
+      md5: 30b6300789b85f9cf8ce067ca905a696
+      size: 1685707
+    - path: subs/oof/arch=resnet18_sz=512_fold=4.csv
+      md5: e80d686815502a81e952250535ca5d08
+      size: 1683124
+  train_efficientnet_b4_256:
+    cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
+      --epochs 15 --arch tf_efficientnet_b4_ns --sz 256 --batch_size 22 --lr 1 --sched
+      onecycle
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 2dfbac030cc5c89a17585ef832abdd7b
+      size: 8159
+    outs:
+    - path: metrics/arch=tf_efficientnet_b4_ns_sz=256.metric
+      md5: bd9e8cc3f4ccb693714fac3cff80ab2d
+      size: 49
+    - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=0.ckpt
+      md5: bc1e0ca47a6f9091e7b1871ed2de9cdf
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=1.ckpt
+      md5: 741fbad628a17a75244da7e0d3ab4291
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=2.ckpt
+      md5: 3227695bfacb4b61f17534b8c92d430c
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=3.ckpt
+      md5: 7c0821d6bf95220c47e0f2c86d83e92e
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=256_fold=4.ckpt
+      md5: 329b4ed99b0ea1ef0f365578a9f86df5
+      size: 71032001
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
+      md5: 5230282872626885db68bd6bfc9d17d2
+      size: 994046
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
+      md5: ff13e4d7746903b6e6bf23c3012ce077
+      size: 989997
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
+      md5: 995818cc457d53adb53364e06f7e8825
+      size: 991256
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
+      md5: c8b1d07acb34b9f50cd7794daf44878f
+      size: 992262
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
+      md5: 8bff869fffc12588d077f5906ccdd08d
+      size: 990444
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
+      md5: fd11768d79e28f48f32d329c9bc6cffa
+      size: 1676231
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
+      md5: 036b82adc98aa8b2e8e726a2b0ae31b7
+      size: 1671098
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
+      md5: a7bd54d47f8e9dec34e5cbc3c60ab39b
+      size: 1677398
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
+      md5: 4a7948a30acfc25b95a641f2071f3e99
+      size: 1677331
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
+      md5: 57509c9dcad5e1cb1ebb909220cdb203
+      size: 1671019
+  train_efficientnet_b4_512:
+    cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 5 --arch tf_efficientnet_b4_ns --sz 512 --batch_size 32 --lr 1 --sched
+      onecycle
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 9fa4cbc5ffe416f796e046ab1f5b97aa
+      size: 8840
+    outs:
+    - path: metrics/arch=tf_efficientnet_b4_ns_sz=512.metric
+      md5: 8f249f493c246e633f4feaf66fe0755d
+      size: 49
+    - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=0.ckpt
+      md5: b50c09f05c3fa2edd67cf5d8f56e9f4b
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=1.ckpt
+      md5: 4e9fd595aebb4eab6e93ba71b6e685e7
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=2.ckpt
+      md5: 0c0d03a0ff939f067e048a1c96f9ead0
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=3.ckpt
+      md5: cebf80349f593f420722dbaacdfb1e03
+      size: 71032001
+    - path: models/arch=tf_efficientnet_b4_ns_sz=512_fold=4.ckpt
+      md5: ad292afdefcb7106bf1d8bbb34034d31
+      size: 71032001
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
+      md5: 2a9d108e226095387969d7854505149b
+      size: 999503
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
+      md5: b071f6b03cb4bcaceeb8eea8a7cfaf20
+      size: 999754
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
+      md5: 0464bc8e1ba695af872b7ef8afe1f408
+      size: 1000900
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
+      md5: 160d19a783da83ed81ca79ff558b971d
+      size: 998228
+    - path: subs/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
+      md5: 5e7a2b18cab6a080dd7f3cd7a66ed0fd
+      size: 996537
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
+      md5: d5f5c9c7b4eaef7e9d8bd2ec4594c737
+      size: 1668531
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
+      md5: 5dec21676d59981c849ffdb65f5c1dff
+      size: 1671022
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
+      md5: a2eb95d767e19210db53c513008a974f
+      size: 1671474
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
+      md5: b8174b190fe201af011a49ec9682e4aa
+      size: 1670604
+    - path: subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
+      md5: e9468e76b7672018833b04f1c28adfa2
+      size: 1673483
+  train_resnest14d_128:
+    cmd: python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
+      --epochs 15 --arch resnest14d --sz 128 --batch_size 128 --lr 1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
+    deps:
+    - path: data/train_128/
+      md5: 569de16f618eff737a4f2a8d3e70eec0.dir
+      size: 72692224
+      nfiles: 30083
+    - path: data/train_256/
+      md5: e14002093f230017b4cc1810a53f0328.dir
+      size: 201194414
+      nfiles: 30083
+    - path: data/train_folds.csv
+      md5: 7f4f0d6630400e2b1218d530fcb99a63
+      size: 2978438
+    - path: pipe/train.py
+      md5: 7d3d93e16cf7510d2997f68a1856917e
+      size: 5959
+    outs:
+    - path: metrics/arch=resnest14d_sz=128.metric
+      md5: 64996527a23e0be4ae24d41cea0d4139
+      size: 49
+    - path: models/arch=resnest14d_sz=128_fold=0.ckpt
+      md5: 64f0fa42b9cd3119057037942d3037db
+      size: 68863867
+    - path: models/arch=resnest14d_sz=128_fold=1.ckpt
+      md5: 3b4ad10e67eb914eac3d795992372f0e
+      size: 68863869
+    - path: models/arch=resnest14d_sz=128_fold=2.ckpt
+      md5: 3e57540710d115a74c4f372a0ed0415b
+      size: 68863867
+    - path: models/arch=resnest14d_sz=128_fold=3.ckpt
+      md5: fdf913d79fff161623730824f78c0ca1
+      size: 68863868
+    - path: models/arch=resnest14d_sz=128_fold=4.ckpt
+      md5: 24501a33be1377b3a624cb5322ae4816
+      size: 68863867
+  train_resnest101e_512:
+    cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest101e --sz 512 --batch_size 16 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 7b347936343e1135b4cb5faaf9e1153a
+      size: 5888
+    outs:
+    - path: metrics/arch=resnest101e_sz=512.metric
+      md5: 7da3b3c004a251ec0fcb1d1dee001381
+      size: 50
+    - path: models/arch=resnest101e_sz=512_fold=0.ckpt
+      md5: bcec379952017b9f84af5ff871fefaa9
+      size: 371087053
+    - path: models/arch=resnest101e_sz=512_fold=1.ckpt
+      md5: ed6851233b5246341f380a8b8811c21c
+      size: 371087054
+    - path: models/arch=resnest101e_sz=512_fold=2.ckpt
+      md5: 25c845fcdb94fc45e7da3f349a04b489
+      size: 371087053
+    - path: models/arch=resnest101e_sz=512_fold=3.ckpt
+      md5: e6805294f7833e4bd3ea4fc8beb938b4
+      size: 371087053
+    - path: models/arch=resnest101e_sz=512_fold=4.ckpt
+      md5: 3ec2bd018dd0aa3ee2a4b88932128133
+      size: 371087053
+  train_resnest200e_512:
+    cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest200e --sz 512 --batch_size 8 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
+    deps:
+    - path: data/train_folds.csv
+      md5: 7f4f0d6630400e2b1218d530fcb99a63
+      size: 2978438
+    - path: pipe/train.py
+      md5: 7d3d93e16cf7510d2997f68a1856917e
+      size: 5959
+    outs:
+    - path: metrics/arch=resnest200e_sz=512.metric
+      md5: 7434334635819f0a43856bc3a6e9a282
+      size: 49
+    - path: models/arch=resnest200e_sz=512_fold=0.ckpt
+      md5: a058edde977443dae635fe1dd4613608
+      size: 547410695
+    - path: models/arch=resnest200e_sz=512_fold=1.ckpt
+      md5: 1798fc5fd57122abb26ec38e14d197d0
+      size: 547410698
+    - path: models/arch=resnest200e_sz=512_fold=2.ckpt
+      md5: fc42d22cad2afc170281981be4bb0580
+      size: 547410696
+    - path: models/arch=resnest200e_sz=512_fold=3.ckpt
+      md5: 8ed2bbf5d55a5ca356d49648cea62d4f
+      size: 547410695
+    - path: models/arch=resnest200e_sz=512_fold=4.ckpt
+      md5: e4b37cdfefffbb6d47e9eba16b44db14
+      size: 547410695
+  train_resnest50d_512:
+    cmd: python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest50d --sz 512 --batch_size 32 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
+    deps:
+    - path: data/train_folds.csv
+      md5: 7a364fa00309d9d50641ae5edcfabcd3
+      size: 2978438
+    - path: pipe/train.py
+      md5: 7b347936343e1135b4cb5faaf9e1153a
+      size: 5888
+    outs:
+    - path: metrics/arch=resnest50d_sz=512.metric
+      md5: 8a7ffe01e5ceaa8dfc315d481fe8287e
+      size: 50
+    - path: models/arch=resnest50d_sz=512_fold=0.ckpt
+      md5: 026c0a1d823cdd47fedcb714faf3d322
+      size: 204207475
+    - path: models/arch=resnest50d_sz=512_fold=1.ckpt
+      md5: 6c1c4e01bd959814f902430c03a3131a
+      size: 204207476
+    - path: models/arch=resnest50d_sz=512_fold=2.ckpt
+      md5: 934c4bcbf3f80308e4e1bff47490e0b3
+      size: 204207475
+    - path: models/arch=resnest50d_sz=512_fold=3.ckpt
+      md5: 0e1ee21057f39e84ab49c4431769f963
+      size: 204207475
+    - path: models/arch=resnest50d_sz=512_fold=4.ckpt
+      md5: c279403b0e673563bb04e9c9603eb8a1
+      size: 204207476

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -72,67 +72,16 @@ stages:
       - pipe/create_folds.py
     outs:
       - data/train_folds.csv
-  train_efficientnet_b4_256:
-    cmd:
-      python pipe/train.py --train_data train_512 --test_data test_512 --fold -1
-      --epochs 10 --arch tf_efficientnet_b4_ns --sz 256 --batch_size 22 --lr 1 --sched
-      onecycle --aug baseline
-    deps:
-      - data/train_folds.csv
-      - pipe/train.py
-    outs:
-      - models/arch=tf_efficientnet_b4_ns_sz=256_fold=0.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=256_fold=1.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=256_fold=2.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=256_fold=3.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=256_fold=4.ckpt
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=256_fold=0.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=256_fold=1.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=256_fold=2.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=256_fold=3.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=256_fold=4.csv
-    metrics:
-      - metrics/arch=tf_efficientnet_b4_ns_sz=256.metric:
-          cache: false
-  train_efficientnet_b4_512:
-    cmd:
-      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
-      -1 --epochs 5 --arch tf_efficientnet_b4_ns --sz 512 --batch_size 32 --lr 1 --sched
-      onecycle --aug baseline
-    deps:
-      - data/train_folds.csv
-      - pipe/train.py
-    outs:
-      - models/arch=tf_efficientnet_b4_ns_sz=512_fold=0.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=512_fold=1.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=512_fold=2.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=512_fold=3.ckpt
-      - models/arch=tf_efficientnet_b4_ns_sz=512_fold=4.ckpt
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
-      - subs/oof/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=512_fold=0.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=512_fold=1.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=512_fold=2.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=512_fold=3.csv
-      - subs/arch=tf_efficientnet_b4_ns_sz=512_fold=4.csv
-    metrics:
-      - metrics/arch=tf_efficientnet_b4_ns_sz=512.metric:
-          cache: false
   train_resnest14d_128:
     cmd:
       python pipe/train.py --train_data train_256 --test_data test_256 --fold -1
       --epochs 15 --arch resnest14d --sz 128 --batch_size 128 --lr 1 --wd 0.00001
-      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt sam
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
     deps:
       - data/train_folds.csv
+      - data/train_128/
+      - data/train_256/
       - pipe/train.py
     outs:
       - models/arch=resnest14d_sz=128_fold=0.ckpt
@@ -145,9 +94,10 @@ stages:
           cache: false
   train_resnest50d_512:
     cmd:
-      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-      --epochs 10 --arch resnest50d --sz 512 --batch_size 32 --lr .1 --wd 0.00001
-      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt sam
+      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest50d --sz 512 --batch_size 32 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
     deps:
       - data/train_folds.csv
       - pipe/train.py
@@ -162,9 +112,10 @@ stages:
           cache: false
   train_resnest101e_512:
     cmd:
-      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-      --epochs 10 --arch resnest101e --sz 512 --batch_size 16 --lr .1 --wd 0.00001
-      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt sam
+      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest101e --sz 512 --batch_size 16 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
     deps:
       - data/train_folds.csv
       - pipe/train.py
@@ -179,9 +130,10 @@ stages:
           cache: false
   train_resnest200e_512:
     cmd:
-      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold -1
-      --epochs 10 --arch resnest200e --sz 512 --batch_size 8 --lr .1 --wd 0.00001
-      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt sam
+      python pipe/train.py --train_data train_1024 --test_data test_1024 --fold
+      -1 --epochs 10 --arch resnest200e --sz 512 --batch_size 8 --lr .1 --wd 0.00001
+      --label_smoothing 0.05 --sched onecycle --aug baseline --precision 32 --opt
+      sam
     deps:
       - data/train_folds.csv
       - pipe/train.py

--- a/metrics/arch=resnest14d_sz=128.metric
+++ b/metrics/arch=resnest14d_sz=128.metric
@@ -1,1 +1,1 @@
-multilabel_auc_macro // Train: 0.8777, CV: 0.8660
+multilabel_auc_macro // Train: 0.8776, CV: 0.8660

--- a/metrics/arch=resnest200e_sz=512.metric
+++ b/metrics/arch=resnest200e_sz=512.metric
@@ -1,1 +1,1 @@
-multilabel_auc_macro // Train: 0.9440, CV: 0.9563
+multilabel_auc_macro // Train: 0.9433, CV: 0.9558

--- a/metrics/arch=resnest50d_sz=512.metric
+++ b/metrics/arch=resnest50d_sz=512.metric
@@ -1,1 +1,0 @@
-multilabel_auc_macro // Train: 0.9528, CV: 0.9479

--- a/params.yaml
+++ b/params.yaml
@@ -1,17 +1,23 @@
 create_folds:
   folds: 5
 
-train_resnet18_128:
-  epochs: 20
-  arch: "resnet18"
+train_resnest14d_128:
+  train_data: "train_256"
+  test_data: "test_256"
+  fold: -1
+  epochs: 15
+  arch: "resnest14d"
   metric: "multilabel_auc_macro"
-  opt: "adam"
+  opt: "sam"
+  sched: "onecycle"
+  aug: "baseline"
   loss: "bce_with_logits"
-  precision: 16
+  precision: 32
   sz: 128
-  bs: 1024
-  lr: 0.02
-  wd: 0.02
+  bs: 128
+  lr: 1
+  wd: 0.00001
+  smoothing: 0.05
   mom: 0.9
 
 train_resnet34_128:

--- a/pipe/train.py
+++ b/pipe/train.py
@@ -160,7 +160,10 @@ def run(hparams: argparse.Namespace):
     # train and validate model
     trainer.fit(model, dm)
 
-    return model.best_train_metric, model.best_valid_metric
+    return (
+        model.best_train_metric.detach().cpu().numpy(),
+        model.best_valid_metric.detach().cpu().numpy(),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- BUG: Failure when computing CV metric due to NumPy operation on PyTorch Tensor
- MAINT: Remove models trained on 256x256 images ― will reintroduce later with better scaling strategy
- MAINT: Reproduce ResNest50d and 200e on 512x512 images, original weights were lost while upgrading DVC and moving the cache to a different HDD